### PR TITLE
ユーザーのインクリメンタルサーチ

### DIFF
--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -1,0 +1,54 @@
+$(function() {
+  // インクリメンタルサーチ
+  function appendUser(user) {
+    var html = `<div class="chat-group-user clearfix">
+                  <p class="chat-group-user__name">${user.name}</p>
+                  <a class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id="${user.id}" data-user-name="${user.name}">追加</a>
+                </div>`
+    $('#user-search-result').append(html);
+  };
+
+  $('#user-search-field.chat-group-form__input').on('keyup', function() {
+    var input = $(this).val();
+    
+    $.ajax({
+      type: 'GET',
+      url: '/users',
+      data: { keyword: input },
+      dataType: 'json'
+    })
+    
+    .done(function(users) {
+      $('#user-search-result').empty();
+      if (users.length !== 0) {
+        users.forEach(function(user){
+          appendUser(user);
+        });
+      }
+    })
+    .fail(function() {
+      alert('ユーザー検索に失敗しました');
+    });
+  });
+
+  // 検索したユーザーの追加
+  function addUserToGroup(user_id, user_name) {
+    var html = `<div class='chat-group-user clearfix js-chat-member' id='chat-group-user-8'>
+                  <input name='group[user_ids][]' type='hidden' value='${user_id}'>
+                  <p class='chat-group-user__name'>${user_name}</p>
+                  <a class='user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn'>削除</a>
+                </div>`
+    $('#chat-group-users').append(html);
+  };
+
+  $(document).on('click', '.user-search-add', function() {
+    var user_id = $(this).attr('data-user-id');
+    var user_name = $(this).attr('data-user-name');
+    addUserToGroup(user_id, user_name);
+      $(this).parent().remove();
+  });
+  
+  $(document).on("click", ".chat-group-user__btn--remove", function(){
+    $(this).parent().remove();
+  });
+});

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -20,11 +20,9 @@ $(function() {
     
     .done(function(users) {
       $('#user-search-result').empty();
-      if (users.length !== 0) {
-        users.forEach(function(user){
+      users.forEach(function(user){
           appendUser(user);
-        });
-      }
+      });
     })
     .fail(function() {
       alert('ユーザー検索に失敗しました');

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,6 +11,14 @@ class UsersController < ApplicationController
     end
   end
 
+  def index
+    @users = User.where.not(id: current_user.id).where('name LIKE(?)', "%#{params[:keyword]}%").limit(20)
+    respond_to do |format|
+      format.html
+      format.json
+    end
+  end
+
   private
   def user_params
     params.require(:user).permit(:name, :email)

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -11,31 +11,21 @@
     .chat-group-form__field--right
       = f.text_field :name, class: 'chat_group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
   .chat-group-form__field.clearfix
-    / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-    /
-      <div class='chat-group-form__field--left'>
-      <label class="chat-group-form__label" for="chat_group_チャットメンバーを追加">チャットメンバーを追加</label>
-      </div>
-      <div class='chat-group-form__field--right'>
-      <div class='chat-group-form__search clearfix'>
-      <input class='chat-group-form__input' id='user-search-field' placeholder='追加したいユーザー名を入力してください' type='text'>
-      </div>
-      <div id='user-search-result'></div>
-      </div>
+    .chat-group-form__field--left
+      %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
+    .chat-group-form__field--right
+      .chat-group-form__search.clearfix
+        %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
+      #user-search-result
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
       %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
-      / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-      = f.collection_check_boxes :user_ids, User.all, :id, :name
-      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-      /
-        <div id='chat-group-users'>
-        <div class='chat-group-user clearfix' id='chat-group-user-22'>
-        <input name='chat_group[user_ids][]' type='hidden' value='22'>
-        <p class='chat-group-user__name'>seo_kyohei</p>
-        </div>
-        </div>
+      #chat-group-user-22.chat-group-user.clearfix
+        %input{:name => "chat_group[user_ids][]", :type => "hidden", :value => "#{current_user.id}"}/
+        %p.chat-group-user__name
+          = current_user.name
+      #chat-group-users
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -22,7 +22,7 @@
       %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
       #chat-group-user-22.chat-group-user.clearfix
-        %input{:name => "chat_group[user_ids][]", :type => "hidden", :value => "#{current_user.id}"}/
+        %input{:name => "group[user_ids][]", :type => "hidden", :value => "#{current_user.id}"}/
         %p.chat-group-user__name
           = current_user.name
       #chat-group-users

--- a/app/views/shared/_side_bar.html.haml
+++ b/app/views/shared/_side_bar.html.haml
@@ -7,7 +7,7 @@
         = link_to new_group_path do
           = fa_icon "edit"
       %li
-        = link_to edit_user_path do
+        = link_to edit_user_path(current_user.id) do
           = fa_icon "cog"
   .sidebar__groups
     .sidebar__groups__list

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @users do |user|
+  json.id user.id
+  json.name user.name
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root 'groups#index'
-  resource :user, only: [:edit, :update]
+  resources :users, only: [:edit, :update, :index]
   resources :groups, only: [:index, :new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
   end


### PR DESCRIPTION
#WHAT
グループメンバーの追加・削除機能にユーザーのインクリメンタルサーチを実装
・ユーザー名を入力すると候補のユーザー（カレントユーザーを除く）が表示される
・追加ボタンを押すとグループにメンバーを追加できる
・削除ボタンを押すとグループからメンバーを削除できる
・カレントユーザーはデフォルトでグループに追加され、削除できない

#WHY
グループメンバーの追加・削除をスムーズに行うことができるようにし、UXを向上させるため